### PR TITLE
Babel の preset の変更

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015-node5"]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "babel": "~6.5.1",
     "babel-cli": "~6.5.1",
-    "babel-preset-es2015": "~6.5.0",
+    "babel-preset-es2015-node5": "~1.1.2",
     "body-parser": "~1.15.0",
     "cookie-parser": "~1.4.1",
     "debug": "~2.2.0",


### PR DESCRIPTION
Babel の preset を Node 5 用のものに変更.
不要な transpile を削減する.
